### PR TITLE
Added support for (query) parameters

### DIFF
--- a/src/main/java/ca/ryangreen/apigateway/generic/GenericApiGatewayClient.java
+++ b/src/main/java/ca/ryangreen/apigateway/generic/GenericApiGatewayClient.java
@@ -6,6 +6,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.auth.AWS4Signer;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.http.AmazonHttpClient;
 import com.amazonaws.http.ExecutionContext;
 import com.amazonaws.http.HttpMethodName;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class GenericApiGatewayClient extends AmazonWebServiceClient {
@@ -64,10 +66,10 @@ public class GenericApiGatewayClient extends AmazonWebServiceClient {
     }
 
     public GenericApiGatewayResponse execute(GenericApiGatewayRequest request) {
-        return execute(request.getHttpMethod(), request.getResourcePath(), request.getHeaders(), request.getBody());
+        return execute(request.getHttpMethod(), request.getResourcePath(), request.getHeaders(), request.getParameters(), request.getBody());
     }
 
-    private GenericApiGatewayResponse execute(HttpMethodName method, String resourcePath, Map<String, String> headers, InputStream content) {
+    private GenericApiGatewayResponse execute(HttpMethodName method, String resourcePath, Map<String, String> headers, Map<String, List<String>> parameters, InputStream content) {
         final ExecutionContext executionContext = buildExecutionContext();
 
         DefaultRequest request = new DefaultRequest(API_GATEWAY_SERVICE_NAME);
@@ -76,8 +78,13 @@ public class GenericApiGatewayClient extends AmazonWebServiceClient {
         request.setEndpoint(this.endpoint);
         request.setResourcePath(resourcePath);
         request.setHeaders(buildRequestHeaders(headers, apiKey));
+        request.setParameters(parameters);
 
-        return this.client.execute(request, responseHandler, errorResponseHandler, executionContext).getAwsResponse();
+        return this.client.requestExecutionBuilder()
+                .request(request)
+                .errorResponseHandler(errorResponseHandler)
+                .executionContext(executionContext)
+                .execute(responseHandler).getAwsResponse().getResult();
     }
 
     private ExecutionContext buildExecutionContext() {

--- a/src/main/java/ca/ryangreen/apigateway/generic/GenericApiGatewayRequest.java
+++ b/src/main/java/ca/ryangreen/apigateway/generic/GenericApiGatewayRequest.java
@@ -2,8 +2,8 @@ package ca.ryangreen.apigateway.generic;
 
 import com.amazonaws.http.HttpMethodName;
 
-import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 public class GenericApiGatewayRequest {
@@ -11,13 +11,16 @@ public class GenericApiGatewayRequest {
     private final String resourcePath;
     private final InputStream body;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> parameters;
 
     public GenericApiGatewayRequest(HttpMethodName httpMethod, String resourcePath,
-                                    InputStream body, Map<String, String> headers) {
+                                    InputStream body, Map<String, String> headers,
+                                    Map<String, List<String>> parameters) {
         this.httpMethod = httpMethod;
         this.resourcePath = resourcePath;
         this.body = body;
         this.headers = headers;
+        this.parameters = parameters;
     }
 
     public HttpMethodName getHttpMethod() {
@@ -34,5 +37,9 @@ public class GenericApiGatewayRequest {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public Map<String, List<String>> getParameters() {
+        return parameters;
     }
 }

--- a/src/main/java/ca/ryangreen/apigateway/generic/GenericApiGatewayRequestBuilder.java
+++ b/src/main/java/ca/ryangreen/apigateway/generic/GenericApiGatewayRequestBuilder.java
@@ -4,6 +4,8 @@ import com.amazonaws.http.HttpMethodName;
 import ca.ryangreen.apigateway.util.Validate;
 
 import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class GenericApiGatewayRequestBuilder {
@@ -11,6 +13,7 @@ public class GenericApiGatewayRequestBuilder {
     private String resourcePath;
     private InputStream body;
     private Map<String, String> headers;
+    private Map<String, List<String>> parameters = new LinkedHashMap<>();
 
     public GenericApiGatewayRequestBuilder withHttpMethod(HttpMethodName name) {
         httpMethod = name;
@@ -32,9 +35,14 @@ public class GenericApiGatewayRequestBuilder {
         return this;
     }
 
+    public GenericApiGatewayRequestBuilder withParameters(Map<String, List<String>> parameters) {
+        this.parameters = parameters;
+        return this;
+    }
+
     public GenericApiGatewayRequest build() {
         Validate.notNull(httpMethod, "HTTP method");
         Validate.notEmpty(resourcePath, "Resource path");
-        return new GenericApiGatewayRequest(httpMethod, resourcePath, body, headers);
+        return new GenericApiGatewayRequest(httpMethod, resourcePath, body, headers, parameters);
     }
 }

--- a/src/test/java/ca/ryangreen/apigateway/generic/GenericApiGatewayClientTest.java
+++ b/src/test/java/ca/ryangreen/apigateway/generic/GenericApiGatewayClientTest.java
@@ -90,7 +90,7 @@ public class GenericApiGatewayClientTest {
                                 && x.getFirstHeader("Account-Id").getValue().equals("fubar")
                                 && x.getFirstHeader("x-api-key").getValue().equals("12345")
                                 && x.getFirstHeader("Authorization").getValue().startsWith("AWS4")
-                                && x.getURI().toString().equals(join( ENDPOINT, RESOURCE_PATH, "?key1=value1"))))),
+                                && x.getURI().toString().equals(join(ENDPOINT, RESOURCE_PATH, "?key1=value1"))))),
                 any(HttpContext.class));
     }
 
@@ -147,7 +147,7 @@ public class GenericApiGatewayClientTest {
         }
     }
 
-    private static String join(String ... values) {
+    private static String join(String... values) {
         return Stream.of(values).collect(Collectors.joining());
     }
 


### PR DESCRIPTION
Perhaps it wasn't necessary for the original use case or maybe an argument could be made that it's still not necessary... regardless, here is a PR that allows for passing parameters/querystrings to the API Gateway.