### PR TITLE
Small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ try {
                     .withResourcePath("/stage/path").build());
     
     System.out.println("Response: " + response.getBody());
-    System.out.println("Status: " + response.getHttpResponse.getStatusCode());
+    System.out.println("Status: " + response.getHttpResponse().getStatusCode());
     
 } catch (GenericApiGatewayException e) {   // exception thrown for any non-2xx response
     System.out.println(String.format("Client threw exception with message %s and status code %s", 


### PR DESCRIPTION
Suggestion to fix a small typo I found. Method `getHttpResponse()` is missing the `()`